### PR TITLE
feat: add function to fund tournament

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	protostar build
 
 test:
-	protostar test contracts/ -m '.*$(match).*'
+	protostar test contracts
 
 date:
 	date

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Tournament logic is also implemented, allowing dozens of players to fight in mul
 
 #### Requirements
 
-- [Protostar](https://github.com/software-mansion/protostar) >= 0.1.0
+- [Protostar](https://github.com/software-mansion/protostar) >= 0.2.1
 - [Python <=3.8](https://www.python.org/downloads/)
 
 #### 📦 Install

--- a/contracts/interfaces/itournament.cairo
+++ b/contracts/interfaces/itournament.cairo
@@ -63,4 +63,7 @@ namespace ITournament:
 
     func played_battle_count() -> (res : felt):
     end
+
+    func deposit_rewards(amount : Uint256) -> (res : felt):
+    end
 end

--- a/contracts/tournament/library.cairo
+++ b/contracts/tournament/library.cairo
@@ -141,6 +141,14 @@ end
 func current_stage_() -> (state : felt):
 end
 
+# ------------------
+# EVENTS
+# ------------------
+
+@event
+func rewards_deposited(depositor_address : felt, amount : Uint256):
+end
+
 namespace tournament:
     # ---------
     # CONSTANTS
@@ -427,6 +435,27 @@ namespace tournament:
         # Push ship to array of playing ships
         playing_ships_.write(current_ship_count, ship_address)
         playing_ship_count_.write(current_ship_count + 1)
+        return (TRUE)
+    end
+
+    # Deposit ERC20 tokens to the tournament as reward
+    # @param amount: the amount of tokens to deposit by caller
+    func deposit_rewards{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+        amount : Uint256
+    ) -> (success : felt):
+        let (reward_token_address) = reward_token_address_.read()
+        let (contract_address) = get_contract_address()
+        let (caller_address) = get_caller_address()
+
+        # Transfer tokens to the tournament contract
+        IERC20.transferFrom(
+            contract_address=reward_token_address,
+            sender=caller_address,
+            recipient=contract_address,
+            amount=amount
+        )
+        # Emit deposit event
+        rewards_deposited.emit(caller_address, amount)
         return (TRUE)
     end
 end

--- a/contracts/tournament/tournament.cairo
+++ b/contracts/tournament/tournament.cairo
@@ -200,3 +200,12 @@ func register{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}
 ) -> (success : felt):
     return tournament.register(ship_address)
 end
+
+# Deposit ERC20 tokens to the tournament as reward
+# @param amount: the amount of tokens to deposit
+@external
+func deposit_rewards{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    amount : Uint256
+) -> (success : felt):
+    return tournament.deposit_rewards(amount)
+end

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,5 +1,5 @@
 ["protostar.config"]
-protostar_version = "0.1.0"
+protostar_version = "0.2.1"
 
 ["protostar.project"]
 libs_path = "lib"


### PR DESCRIPTION
This PR is for issue https://github.com/onlydustxyz/starkonquest/issues/44.

The goal is to allow people to fund the tournament, in the form of ERC20 tokens. Upon inspection, it already had the getter function for the ERC20 token address and the value is only set in the constructor (not changeable). I've proceed and did the following:
- create `deposit_rewards` **external** function that
  transfers ERC20 tokens from caller to the tournament contract
- create `rewards_deposited` **event**
- add test for depositing rewards
- update protostar version to 0.2.1
- add namespace for integration test related functions
- update ITournament interface