### PR TITLE
Store ships and dusts positions in grid, loop on positions instead of the whole grid

### DIFF
--- a/contracts/core/battle/library.cairo
+++ b/contracts/core/battle/library.cairo
@@ -202,6 +202,8 @@ namespace battle:
             grid_access.set_cell_at(position.x, position.y, cell)
         end
 
+        # Store initial ship position
+        grid_access.add_ship_position(position)
         # Emit events
         let (battle_contract_address) = get_contract_address()
         ship_added.emit(battle_contract_address, ship_id, Vector2(position.x, position.y))

--- a/contracts/core/battle/test_battle.cairo
+++ b/contracts/core/battle/test_battle.cairo
@@ -46,6 +46,10 @@ func add_ship_at{range_check_ptr, grid : Grid}(x : felt, y : felt, ship_id : fel
     local range_check_ptr = range_check_ptr  # revoked reference
     cell_access.add_ship{cell=cell}(ship_id)
     grid_access.set_cell_at(x, y, cell)
+
+    let position = Vector2(x=x, y=y)
+    grid_access.add_ship_position(position)
+
     return ()
 end
 
@@ -372,9 +376,9 @@ func test_full_battle{syscall_ptr : felt*, range_check_ptr}():
             %}
             battle.all_turns_loop()
         end
-
+        # grid_helper.debug_grid()
         with_attr error_message("Something wrong with the battle"):
-            assert_ship_at(7, 2, ship1)  # assert_ship_at(6, 3, ship1)
+            assert_ship_at(6, 3, ship1)  # assert_ship_at(7, 2, ship1)  # assert_ship_at(6, 3, ship1)
             assert_ship_at(4, 1, ship2)
             assert_dust_count_at(3, 1, 1)
             assert_dust_count_at(4, 2, 1)
@@ -406,10 +410,10 @@ func test_play_game{syscall_ptr : felt*, range_check_ptr}():
 
     %{
         mock_call(ids.RAND_CONTRACT, 'generate_random_numbers', [
-                                                2, 2, # direction => (1, 1)
-                                                0, 2, # position => (0, 2)
-                                                1 # shuffled position (0, 2) => (2, 0)
-                                                ])
+                                                        2, 2, # direction => (1, 1)
+                                                        0, 2, # position => (0, 2)
+                                                        1 # shuffled position (0, 2) => (2, 0)
+                                                        ])
 
         mock_call(ids.ship1, "move", [1, -1])
         mock_call(ids.ship2, "move", [0, -1])

--- a/contracts/core/battle/test_battle.cairo
+++ b/contracts/core/battle/test_battle.cairo
@@ -33,9 +33,13 @@ func assert_dust_at{range_check_ptr, grid : Grid}(x : felt, y : felt, dust : Dus
 end
 
 func add_dust_at{range_check_ptr, grid : Grid}(x : felt, y : felt, dust : Dust):
-    let (cell) = grid_access.get_cell_at(x, y)
+    alloc_locals
+    let (local cell) = grid_access.get_cell_at(x, y)
+    let position = Vector2(x=x, y=y)
+    grid_access.add_dust_position(position)
     cell_access.add_dust{cell=cell}(dust)
     grid_access.set_cell_at(x, y, cell)
+
     return ()
 end
 
@@ -262,7 +266,7 @@ func test_battle_ship_absorb_dust{syscall_ptr : felt*, range_check_ptr}():
 
         local dust_count = 1
         with dust_count:
-            battle.check_ship_and_dust_collisions()
+            battle.check_ship_and_dust_collisions_loop(0)
         end
 
         with_attr error_message("bad dust move"):
@@ -366,10 +370,10 @@ func test_full_battle{syscall_ptr : felt*, range_check_ptr}():
         with dust_count, current_turn:
             %{
                 mock_call(ids.RAND_CONTRACT, 'generate_random_numbers', [
-                                        2, 2, # direction => (1, 1)
-                                        0, 2, # position => (0, 2)
-                                           1 # shuffled position (0, 2) => (2, 0)
-                                               ])
+                                                        2, 2, # direction => (1, 1)
+                                                        0, 2, # position => (0, 2)
+                                                        1 # shuffled position (0, 2) => (2, 0)
+                                                               ])
 
                 mock_call(ids.ship1, "move", [1, -1])
                 mock_call(ids.ship2, "move", [0, -1])
@@ -410,10 +414,10 @@ func test_play_game{syscall_ptr : felt*, range_check_ptr}():
 
     %{
         mock_call(ids.RAND_CONTRACT, 'generate_random_numbers', [
-                                                        2, 2, # direction => (1, 1)
-                                                        0, 2, # position => (0, 2)
-                                                        1 # shuffled position (0, 2) => (2, 0)
-                                                        ])
+                                                                2, 2, # direction => (1, 1)
+                                                                0, 2, # position => (0, 2)
+                                                                1 # shuffled position (0, 2) => (2, 0)
+                                                                ])
 
         mock_call(ids.ship1, "move", [1, -1])
         mock_call(ids.ship2, "move", [0, -1])

--- a/contracts/libraries/move.cairo
+++ b/contracts/libraries/move.cairo
@@ -31,13 +31,13 @@ end
 namespace move_strategy:
     # Move all dusts on the grid according to their direction, bouncing if needed
     func move_all_dusts{syscall_ptr : felt*, range_check_ptr, grid : Grid}():
-        let (grid_iterator) = grid_access.start()
-        let (dust_positions_array : Vector2*) = alloc()
-        let dust_positions_array_len = 0
-        with grid_iterator, dust_positions_array, dust_positions_array_len:
-            internal.find_dust_to_move_loop()
-        end
-        with dust_positions_array, dust_positions_array_len:
+        alloc_locals
+        local dusts_positions : Vector2*
+        local dusts_positions_len : felt
+        assert dusts_positions = grid.dusts_positions
+        assert dusts_positions_len = grid.dusts_positions_len
+        let dust_merged_count = 0
+        with dusts_positions_len, dusts_positions, dust_merged_count:
             internal.move_relevant_dust_loop(0)
         end
 
@@ -55,65 +55,22 @@ namespace move_strategy:
     # PUBLIC NAMESPACE
     # ------------------
     namespace internal:
-        func find_dust_to_move_loop{
-            syscall_ptr : felt*,
-            range_check_ptr,
-            grid : Grid,
-            grid_iterator : Vector2,
-            dust_positions_array : Vector2*,
-            dust_positions_array_len : felt,
-        }():
-            alloc_locals
-            local grid_iterator : Vector2 = grid_iterator
-            let (done) = grid_access.done()
-            if done == 1:
-                return ()
-            end
-
-            try_add_single_dust_position()
-            grid_access.next()
-            return find_dust_to_move_loop()
-        end
-
-        func try_add_single_dust_position{
-            syscall_ptr : felt*,
-            range_check_ptr,
-            grid : Grid,
-            grid_iterator : Vector2,
-            dust_positions_array : Vector2*,
-            dust_positions_array_len : felt,
-        }():
-            alloc_locals
-
-            let (cell) = grid_access.get_cell_at(grid_iterator.x, grid_iterator.y)
-
-            local range_check_ptr = range_check_ptr  # Revoked reference
-
-            let (has_dust) = cell_access.has_dust{cell=cell}()
-            if has_dust == 0:
-                return ()
-            end
-            # Add the dust psition to the end of vector_array
-            assert dust_positions_array[dust_positions_array_len] = grid_iterator  # [vector_array + vector_array_len * Vector2.SIZE] = grid_iterator
-            let dust_positions_array_len = dust_positions_array_len + 1
-
-            return ()
-        end
         func move_relevant_dust_loop{
             syscall_ptr : felt*,
             range_check_ptr,
             grid : Grid,
-            dust_positions_array : Vector2*,
-            dust_positions_array_len : felt,
+            dusts_positions_len : felt,
+            dusts_positions : Vector2*,
+            dust_merged_count : felt,
         }(index : felt):
             alloc_locals
-            if index == dust_positions_array_len:
+            if index == dusts_positions_len:
                 return ()
             end
-            let position : Vector2 = dust_positions_array[index]  # [vector_array + index * Vector2.SIZE]
+            let position : Vector2 = dusts_positions[index]
             let (cell) = grid_access.get_cell_at(position.x, position.y)
             let (dust) = cell_access.get_dust{cell=cell}()
-            move_single_dust(position, dust)
+            move_single_dust(position, dust, index)
 
             # Remove dust from current cell
             with cell:
@@ -123,9 +80,9 @@ namespace move_strategy:
 
             return move_relevant_dust_loop(index + 1)
         end
-        func move_single_dust{syscall_ptr : felt*, range_check_ptr, grid : Grid}(
-            position : Vector2, dust : Dust
-        ):
+        func move_single_dust{
+            syscall_ptr : felt*, range_check_ptr, grid : Grid, dust_merged_count : felt
+        }(position : Vector2, dust : Dust, index : felt):
             alloc_locals
 
             # Bounce if needed
@@ -139,7 +96,8 @@ namespace move_strategy:
 
             # Modify the dust direction in it
             cell_access.add_dust{cell=new_cell}(Dust(new_direction))
-
+            # Update dusts position
+            grid_access.update_dust_position_at_index(index - dust_merged_count, new_dust_position)
             # Store the new cell
             grid_access.set_cell_at(new_dust_position.x, new_dust_position.y, new_cell)
 

--- a/contracts/libraries/test_move.cairo
+++ b/contracts/libraries/test_move.cairo
@@ -24,6 +24,10 @@ func add_ship_at{range_check_ptr, grid : Grid}(x : felt, y : felt, ship_id : fel
     let (cell) = cell_access.create()
     cell_access.add_ship{cell=cell}(ship_id)
     grid_access.set_cell_at(x, y, cell)
+
+    let position = Vector2(x=x, y=y)
+
+    grid_access.add_ship_position(position)
     return ()
 end
 
@@ -195,8 +199,8 @@ func test_move_ship_collision_in_next_grid{syscall_ptr : felt*, range_check_ptr}
         %}
 
         with_attr error_message("bad ship move"):
-            assert_ship_at(0, 1, ship1)
-            assert_ship_at(1, 1, ship2)
+            assert_ship_at(1, 1, ship1)
+            assert_ship_at(1, 0, ship2)
             # TODO ship_moved.emit(space_contract_address, ship_id, grid_iterator, new_position)
         end
     end

--- a/contracts/libraries/test_move.cairo
+++ b/contracts/libraries/test_move.cairo
@@ -8,9 +8,13 @@ from contracts.test.grid_helper import grid_helper
 from starkware.cairo.common.alloc import alloc
 
 func add_dust_at{range_check_ptr, grid : Grid}(x : felt, y : felt, dust : Dust):
+    let position = Vector2(x=x, y=y)
+    grid_access.add_dust_position(position)
+
     let (cell) = cell_access.create()
     cell_access.add_dust{cell=cell}(dust)
     grid_access.set_cell_at(x, y, cell)
+
     return ()
 end
 

--- a/contracts/libraries/test_square_grid.cairo
+++ b/contracts/libraries/test_square_grid.cairo
@@ -10,12 +10,6 @@ func assert_cell_at{range_check_ptr, grid : Grid}(x : felt, y : felt, cell : Cel
     return ()
 end
 
-# func assert_next_cell_at{range_check_ptr, grid : Grid}(x : felt, y : felt, cell : Cell):
-#     let (next_cell) = grid_access.get_next_cell_at(x, y)
-#     assert next_cell = cell
-#     return ()
-# end
-
 func assert_crossing_border{grid : Grid}(
     position : Vector2, direction : Vector2, crossing_border : Vector2
 ):
@@ -33,9 +27,6 @@ func test_grid_create{range_check_ptr}():
     let (local grid) = grid_access.create(2)
     let (empty_cell) = cell_access.create()
 
-    let (random_cell) = cell_access.create()
-    cell_access.add_ship{cell=random_cell}(23)
-
     assert grid.width = 2
     assert grid.cell_count = 4
 
@@ -44,15 +35,7 @@ func test_grid_create{range_check_ptr}():
         assert_cell_at(0, 1, empty_cell)
         assert_cell_at(1, 0, empty_cell)
         assert_cell_at(1, 1, empty_cell)
-
-        # assert_next_cell_at(0, 0, empty_cell)
-        # assert_next_cell_at(0, 1, empty_cell)
-        # assert_next_cell_at(1, 0, empty_cell)
-        # assert_next_cell_at(1, 1, empty_cell)
     end
-
-    # assert grid.current_cells[4] = random_cell  # Make sure the memory is free after the last cell
-    # assert grid.next_cells[4] = random_cell  # Make sure the memory is free after the last cell
 
     return ()
 end
@@ -72,12 +55,6 @@ func test_grid_update{range_check_ptr}():
 
         grid_access.set_cell_at(0, 1, cell_with_ship)
         assert_cell_at(0, 1, cell_with_ship)
-
-        # assert_next_cell_at(0, 1, cell_with_ship)
-
-        # grid_access.apply_modifications()
-
-        # assert_next_cell_at(0, 1, empty_cell)
     end
 
     return ()
@@ -199,6 +176,25 @@ func test_grid_iterator{range_check_ptr}():
         end
     end
 
+    return ()
+end
+
+@external
+func test_update_ship_position{range_check_ptr}():
+    let (grid) = grid_access.create(8)
+
+    with grid:
+        let pos1 = Vector2(0, 1)
+        let pos2 = Vector2(2, 2)
+        let pos3 = Vector2(1, 5)
+        grid_access.add_ship_position(pos1)
+        grid_access.add_ship_position(pos2)
+        grid_access.add_ship_position(pos3)
+
+        let new_pos2 = Vector2(2, 5)
+        grid_access.update_ship_position_at_index(1, new_pos2)
+    end
+    assert grid.ships_positions[1] = new_pos2
     return ()
 end
 


### PR DESCRIPTION
This PR implements #61 to improve battle speeds. 

**Cairo steps for a full battle on a 10*10 grid in tests decreased from 697599 to 195318, which is ~3.5 times faster !** 

Try run `protostar test contracts/core/battle` to compare. 

And the bigger the grid, the bigger this multiple should be. 

I also squashed the grid dict at the end of a battle (in core/battle/library) to prevent malicious prover actions. 

