### PR TITLE
upgrade protostar and cairo-lang versions to latest

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,7 +13,7 @@ jobs:
           cache: "pip"
       - name: Install dependencies
         run: | # Install latest version from https://pypi.org/simple/cairo-lang/ (as done in nile)
-          pip install https://files.pythonhosted.org/packages/c0/f6/c850604895a2ce5ff3ef77cdb470b6b0ef50889645748a748e18a1c2269e/cairo-lang-0.8.1.post1.zip#sha256=b3c1a23078ba4e0c8ec45d2cd2ba4873ad70b6723dfba70f70c978c9723ff6eb
+          pip install cairo-lang==0.9.1
       - name: Check files formatting
         run: cairo-format -c contracts/**/*.cairo
   python:

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,5 +1,5 @@
 ["protostar.config"]
-protostar_version = "0.2.1"
+protostar_version = "0.3.1"
 
 ["protostar.project"]
 libs_path = "lib"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://files.pythonhosted.org/packages/c0/f6/c850604895a2ce5ff3ef77cdb470b6b0ef50889645748a748e18a1c2269e/cairo-lang-0.8.1.post1.zip#sha256=b3c1a23078ba4e0c8ec45d2cd2ba4873ad70b6723dfba70f70c978c9723ff6eb
+cairo-lang==0.9.1
 cairo-nile
 openzeppelin-cairo-contracts
 marshmallow-dataclass==8.5.3


### PR DESCRIPTION
Updates protostar to 0.3.1 and cairo-lang to 0.9.1